### PR TITLE
feat(access_flow_v2): add requestor_identity_type attribute

### DIFF
--- a/docs/resources/access_flow_v2.md
+++ b/docs/resources/access_flow_v2.md
@@ -77,7 +77,7 @@ resource "apono_access_flow_v2" "aws_auto_grant_flow" {
 
 ### Agent Access Flow — Requestor Identity Type
 
-Restrict a flow to AI agents acting on behalf of a user by setting `requestor_identity_type = "AGENT"`. Omit the attribute (or set it to `"HUMAN"`) for the default human-requestor behavior. Agent flows are request-driven and do not support the `AUTOMATIC` trigger.
+Restrict a flow to AI agents acting on behalf of a user by setting `requestor_identity_type = "AGENT"`. Omit the attribute (or set it to `"HUMAN"`) for the default human-requestor behavior. Agent flows are request-driven; Apono rejects the combination of `requestor_identity_type = "AGENT"` with `trigger = "AUTOMATIC"` and returns an error.
 
 ```terraform
 resource "apono_access_flow_v2" "agent_prod_db" {

--- a/docs/resources/access_flow_v2.md
+++ b/docs/resources/access_flow_v2.md
@@ -75,6 +75,50 @@ resource "apono_access_flow_v2" "aws_auto_grant_flow" {
 }
 ```
 
+### Agent Access Flow — Requestor Identity Type
+
+Restrict a flow to AI agents acting on behalf of a user by setting `requestor_identity_type = "AGENT"`. Omit the attribute (or set it to `"HUMAN"`) for the default human-requestor behavior. Agent flows are request-driven and do not support the `AUTOMATIC` trigger.
+
+```terraform
+resource "apono_access_flow_v2" "agent_prod_db" {
+  name                    = "Agent access to production DBs"
+  active                  = true
+  grant_duration_in_min   = 60
+  trigger                 = "SELF_SERVE"
+  requestor_identity_type = "AGENT"
+
+  requestors = {
+    logical_operator = "AND"
+    conditions = [
+      {
+        type           = "group"
+        match_operator = "contains"
+        values         = ["RND-team"]
+      }
+    ]
+  }
+
+  access_targets = [
+    {
+      integration = {
+        integration_name = "aws-account-prod"
+        resource_type    = "aws-account-s3-bucket"
+        permissions      = ["ReadOnlyAccess"]
+      }
+    }
+  ]
+
+  settings = {
+    justification_required        = true
+    requester_cannot_approve_self = true
+    require_mfa                   = false
+    max_extensions                = 0
+    extension_duration_in_min     = 0
+    labels                        = ["agentic"]
+  }
+}
+```
+
 ### Auto-approved Access Flow for on-call OpsGenie responders
 
 Auto-approved Access Flow for on-call OpsGenie responders to request access on behalf of the R&D group.
@@ -616,6 +660,7 @@ In automatic access flows, requestors specify who will automatically receive acc
 - `escalation_policy` (Attributes) Defines an approval escalation policy for a human approval flow. When a request remains pending for the configured interval, Apono escalates it to the approver groups defined in this block. Previously notified approvers can still approve or reject the request even after escalation was triggered. Up to 5 escalation approver groups are supported. (see [below for nested schema](#nestedatt--escalation_policy))
 - `grant_duration_in_min` (Number) How long access is granted, in minutes. If not specified, the grant duration defaults to indefinite.
 - `request_for` (Attributes) Defines who the access request can be made for. This enables support to request on behalf of other users, groups, or identities. Only applicable in self-serve access flows (trigger = "SELF_SERVE"). (see [below for nested schema](#nestedatt--request_for))
+- `requestor_identity_type` (String) The type of identity that can request access through this flow. HUMAN (default) = reachable only by human requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed values: HUMAN, AGENT.
 - `space_reference` (String) Name of the space to create this resource in. If omitted, the resource is created without a space. Changing this value forces the resource to be replaced.
 - `timeframe` (Attributes) Restrict when access can be granted. Only applicable in self-serve access flows (trigger = "SELF_SERVE"). (see [below for nested schema](#nestedatt--timeframe))
 

--- a/examples/resources/apono_access_flow_v2/agent-identity.tf
+++ b/examples/resources/apono_access_flow_v2/agent-identity.tf
@@ -1,0 +1,37 @@
+resource "apono_access_flow_v2" "agent_prod_db" {
+  name                    = "Agent access to production DBs"
+  active                  = true
+  grant_duration_in_min   = 60
+  trigger                 = "SELF_SERVE"
+  requestor_identity_type = "AGENT"
+
+  requestors = {
+    logical_operator = "AND"
+    conditions = [
+      {
+        type           = "group"
+        match_operator = "contains"
+        values         = ["RND-team"]
+      }
+    ]
+  }
+
+  access_targets = [
+    {
+      integration = {
+        integration_name = "aws-account-prod"
+        resource_type    = "aws-account-s3-bucket"
+        permissions      = ["ReadOnlyAccess"]
+      }
+    }
+  ]
+
+  settings = {
+    justification_required        = true
+    requester_cannot_approve_self = true
+    require_mfa                   = false
+    max_extensions                = 0
+    extension_duration_in_min     = 0
+    labels                        = ["agentic"]
+  }
+}

--- a/internal/v2/api/client/oas_client_gen.go
+++ b/internal/v2/api/client/oas_client_gen.go
@@ -2634,6 +2634,23 @@ func (c *Client) sendListAccessFlowsV2(ctx context.Context, params ListAccessFlo
 		}
 	}
 	{
+		// Encode "requestor_identity_type" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "requestor_identity_type",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.RequestorIdentityType.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
 		// Encode "space_references" parameter.
 		cfg := uri.QueryParameterEncodingConfig{
 			Name:    "space_references",

--- a/internal/v2/api/client/oas_json_gen.go
+++ b/internal/v2/api/client/oas_json_gen.go
@@ -602,6 +602,10 @@ func (s *AccessFlowUpsertV2) encodeFields(e *jx.Encoder) {
 		e.Str(s.Trigger)
 	}
 	{
+		e.FieldStart("requestor_identity_type")
+		e.Str(s.RequestorIdentityType)
+	}
+	{
 		e.FieldStart("requestors")
 		s.Requestors.Encode(e)
 	}
@@ -653,20 +657,21 @@ func (s *AccessFlowUpsertV2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfAccessFlowUpsertV2 = [13]string{
+var jsonFieldsNameOfAccessFlowUpsertV2 = [14]string{
 	0:  "name",
 	1:  "description",
 	2:  "active",
 	3:  "trigger",
-	4:  "requestors",
-	5:  "request_for",
-	6:  "access_targets",
-	7:  "approver_policy",
-	8:  "escalation_policy",
-	9:  "grant_duration_in_min",
-	10: "timeframe",
-	11: "settings",
-	12: "request_for_others",
+	4:  "requestor_identity_type",
+	5:  "requestors",
+	6:  "request_for",
+	7:  "access_targets",
+	8:  "approver_policy",
+	9:  "escalation_policy",
+	10: "grant_duration_in_min",
+	11: "timeframe",
+	12: "settings",
+	13: "request_for_others",
 }
 
 // Decode decodes AccessFlowUpsertV2 from json.
@@ -724,8 +729,20 @@ func (s *AccessFlowUpsertV2) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"trigger\"")
 			}
-		case "requestors":
+		case "requestor_identity_type":
 			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Str()
+				s.RequestorIdentityType = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"requestor_identity_type\"")
+			}
+		case "requestors":
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				if err := s.Requestors.Decode(d); err != nil {
 					return err
@@ -745,7 +762,7 @@ func (s *AccessFlowUpsertV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"request_for\"")
 			}
 		case "access_targets":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				s.AccessTargets = make([]AccessTargetUpsertV2, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -803,7 +820,7 @@ func (s *AccessFlowUpsertV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"timeframe\"")
 			}
 		case "settings":
-			requiredBitSet[1] |= 1 << 3
+			requiredBitSet[1] |= 1 << 4
 			if err := func() error {
 				if err := s.Settings.Decode(d); err != nil {
 					return err
@@ -813,7 +830,7 @@ func (s *AccessFlowUpsertV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"settings\"")
 			}
 		case "request_for_others":
-			requiredBitSet[1] |= 1 << 4
+			requiredBitSet[1] |= 1 << 5
 			if err := func() error {
 				v, err := d.Bool()
 				s.RequestForOthers = bool(v)
@@ -834,8 +851,8 @@ func (s *AccessFlowUpsertV2) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
-		0b01011101,
-		0b00011000,
+		0b10111101,
+		0b00110000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -913,6 +930,10 @@ func (s *AccessFlowV2) encodeFields(e *jx.Encoder) {
 		e.Str(s.Trigger)
 	}
 	{
+		e.FieldStart("requestor_identity_type")
+		e.Str(s.RequestorIdentityType)
+	}
+	{
 		e.FieldStart("requestors")
 		s.Requestors.Encode(e)
 	}
@@ -976,23 +997,24 @@ func (s *AccessFlowV2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfAccessFlowV2 = [16]string{
+var jsonFieldsNameOfAccessFlowV2 = [17]string{
 	0:  "id",
 	1:  "name",
 	2:  "description",
 	3:  "active",
 	4:  "trigger",
-	5:  "requestors",
-	6:  "request_for",
-	7:  "access_targets",
-	8:  "approver_policy",
-	9:  "escalation_policy",
-	10: "grant_duration_in_min",
-	11: "timeframe",
-	12: "settings",
-	13: "space",
-	14: "creation_date",
-	15: "update_date",
+	5:  "requestor_identity_type",
+	6:  "requestors",
+	7:  "request_for",
+	8:  "access_targets",
+	9:  "approver_policy",
+	10: "escalation_policy",
+	11: "grant_duration_in_min",
+	12: "timeframe",
+	13: "settings",
+	14: "space",
+	15: "creation_date",
+	16: "update_date",
 }
 
 // Decode decodes AccessFlowV2 from json.
@@ -1000,7 +1022,7 @@ func (s *AccessFlowV2) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode AccessFlowV2 to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -1062,8 +1084,20 @@ func (s *AccessFlowV2) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"trigger\"")
 			}
-		case "requestors":
+		case "requestor_identity_type":
 			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Str()
+				s.RequestorIdentityType = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"requestor_identity_type\"")
+			}
+		case "requestors":
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				if err := s.Requestors.Decode(d); err != nil {
 					return err
@@ -1083,7 +1117,7 @@ func (s *AccessFlowV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"request_for\"")
 			}
 		case "access_targets":
-			requiredBitSet[0] |= 1 << 7
+			requiredBitSet[1] |= 1 << 0
 			if err := func() error {
 				s.AccessTargets = make([]AccessTargetV2, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -1141,7 +1175,7 @@ func (s *AccessFlowV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"timeframe\"")
 			}
 		case "settings":
-			requiredBitSet[1] |= 1 << 4
+			requiredBitSet[1] |= 1 << 5
 			if err := func() error {
 				if err := s.Settings.Decode(d); err != nil {
 					return err
@@ -1161,7 +1195,7 @@ func (s *AccessFlowV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"space\"")
 			}
 		case "creation_date":
-			requiredBitSet[1] |= 1 << 6
+			requiredBitSet[1] |= 1 << 7
 			if err := func() error {
 				if err := s.CreationDate.Decode(d); err != nil {
 					return err
@@ -1189,9 +1223,10 @@ func (s *AccessFlowV2) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
-		0b10111011,
-		0b01010000,
+	for i, mask := range [3]uint8{
+		0b01111011,
+		0b10100001,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -3003,6 +3038,12 @@ func (s *BundleV2) encodeFields(e *jx.Encoder) {
 		e.Str(s.Name)
 	}
 	{
+		if s.Description.Set {
+			e.FieldStart("description")
+			s.Description.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("access_targets")
 		e.ArrStart()
 		for _, elem := range s.AccessTargets {
@@ -3026,13 +3067,14 @@ func (s *BundleV2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfBundleV2 = [6]string{
+var jsonFieldsNameOfBundleV2 = [7]string{
 	0: "id",
 	1: "name",
-	2: "access_targets",
-	3: "space",
-	4: "creation_date",
-	5: "update_date",
+	2: "description",
+	3: "access_targets",
+	4: "space",
+	5: "creation_date",
+	6: "update_date",
 }
 
 // Decode decodes BundleV2 from json.
@@ -3068,8 +3110,18 @@ func (s *BundleV2) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"name\"")
 			}
+		case "description":
+			if err := func() error {
+				s.Description.Reset()
+				if err := s.Description.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"description\"")
+			}
 		case "access_targets":
-			requiredBitSet[0] |= 1 << 2
+			requiredBitSet[0] |= 1 << 3
 			if err := func() error {
 				s.AccessTargets = make([]AccessBundleAccessTargetV2, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -3097,7 +3149,7 @@ func (s *BundleV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"space\"")
 			}
 		case "creation_date":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				if err := s.CreationDate.Decode(d); err != nil {
 					return err
@@ -3107,7 +3159,7 @@ func (s *BundleV2) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"creation_date\"")
 			}
 		case "update_date":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				if err := s.UpdateDate.Decode(d); err != nil {
 					return err
@@ -3126,7 +3178,7 @@ func (s *BundleV2) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00110111,
+		0b01101011,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -12779,6 +12831,12 @@ func (s *UpsertBundleV2) encodeFields(e *jx.Encoder) {
 		e.Str(s.Name)
 	}
 	{
+		if s.Description.Set {
+			e.FieldStart("description")
+			s.Description.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("access_targets")
 		e.ArrStart()
 		for _, elem := range s.AccessTargets {
@@ -12788,9 +12846,10 @@ func (s *UpsertBundleV2) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUpsertBundleV2 = [2]string{
+var jsonFieldsNameOfUpsertBundleV2 = [3]string{
 	0: "name",
-	1: "access_targets",
+	1: "description",
+	2: "access_targets",
 }
 
 // Decode decodes UpsertBundleV2 from json.
@@ -12814,8 +12873,18 @@ func (s *UpsertBundleV2) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"name\"")
 			}
+		case "description":
+			if err := func() error {
+				s.Description.Reset()
+				if err := s.Description.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"description\"")
+			}
 		case "access_targets":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				s.AccessTargets = make([]AccessBundleAccessTargetUpsertV2, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -12842,7 +12911,7 @@ func (s *UpsertBundleV2) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/internal/v2/api/client/oas_parameters_gen.go
+++ b/internal/v2/api/client/oas_parameters_gen.go
@@ -122,6 +122,8 @@ type GetUserParams struct {
 type ListAccessFlowsV2Params struct {
 	Limit     OptInt32     `json:",omitempty,omitzero"`
 	PageToken OptNilString `json:",omitempty,omitzero"`
+	// Filter access flows by the requestor identity type they serve. Allowed values: HUMAN, AGENT.
+	RequestorIdentityType OptNilString `json:",omitempty,omitzero"`
 	// List of space IDs or names to filter results by. If omitted, returns objects from all spaces. To
 	// return only objects that belong to no space, include the special value "null" in the list.
 	SpaceReferences OptNilStringArray `json:",omitempty,omitzero"`

--- a/internal/v2/api/client/oas_schemas_gen.go
+++ b/internal/v2/api/client/oas_schemas_gen.go
@@ -241,12 +241,16 @@ type AccessFlowUpsertV2 struct {
 	// Activity state of the access flow (active or inactive).
 	Active bool `json:"active"`
 	// Event or action that triggers the access flow.
-	Trigger          string                         `json:"trigger"`
-	Requestors       RequestorsUpsertV2             `json:"requestors"`
-	RequestFor       OptNilRequestForUpsertV2       `json:"request_for"`
-	AccessTargets    []AccessTargetUpsertV2         `json:"access_targets"`
-	ApproverPolicy   OptNilApproverPolicyUpsertV2   `json:"approver_policy"`
-	EscalationPolicy OptNilEscalationPolicyUpsertV2 `json:"escalation_policy"`
+	Trigger string `json:"trigger"`
+	// The type of identity that can request access through this flow. HUMAN (default) = reachable only
+	// by human requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed
+	// values: HUMAN, AGENT.
+	RequestorIdentityType string                         `json:"requestor_identity_type"`
+	Requestors            RequestorsUpsertV2             `json:"requestors"`
+	RequestFor            OptNilRequestForUpsertV2       `json:"request_for"`
+	AccessTargets         []AccessTargetUpsertV2         `json:"access_targets"`
+	ApproverPolicy        OptNilApproverPolicyUpsertV2   `json:"approver_policy"`
+	EscalationPolicy      OptNilEscalationPolicyUpsertV2 `json:"escalation_policy"`
 	// Duration of access granted to the user, in minutes.
 	GrantDurationInMin OptNilInt32                 `json:"grant_duration_in_min"`
 	Timeframe          OptNilAccessFlowTimeframeV2 `json:"timeframe"`
@@ -272,6 +276,11 @@ func (s *AccessFlowUpsertV2) GetActive() bool {
 // GetTrigger returns the value of Trigger.
 func (s *AccessFlowUpsertV2) GetTrigger() string {
 	return s.Trigger
+}
+
+// GetRequestorIdentityType returns the value of RequestorIdentityType.
+func (s *AccessFlowUpsertV2) GetRequestorIdentityType() string {
+	return s.RequestorIdentityType
 }
 
 // GetRequestors returns the value of Requestors.
@@ -339,6 +348,11 @@ func (s *AccessFlowUpsertV2) SetTrigger(val string) {
 	s.Trigger = val
 }
 
+// SetRequestorIdentityType sets the value of RequestorIdentityType.
+func (s *AccessFlowUpsertV2) SetRequestorIdentityType(val string) {
+	s.RequestorIdentityType = val
+}
+
 // SetRequestors sets the value of Requestors.
 func (s *AccessFlowUpsertV2) SetRequestors(val RequestorsUpsertV2) {
 	s.Requestors = val
@@ -395,12 +409,16 @@ type AccessFlowV2 struct {
 	// Activity state of the access flow (active or inactive).
 	Active bool `json:"active"`
 	// Event or action that triggers the access flow.
-	Trigger          string                   `json:"trigger"`
-	Requestors       RequestorsV2             `json:"requestors"`
-	RequestFor       OptNilRequestForV2       `json:"request_for"`
-	AccessTargets    []AccessTargetV2         `json:"access_targets"`
-	ApproverPolicy   OptNilApproverPolicyV2   `json:"approver_policy"`
-	EscalationPolicy OptNilEscalationPolicyV2 `json:"escalation_policy"`
+	Trigger string `json:"trigger"`
+	// The type of identity that can request access through this flow. HUMAN = reachable only by human
+	// requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed values: HUMAN,
+	// AGENT.
+	RequestorIdentityType string                   `json:"requestor_identity_type"`
+	Requestors            RequestorsV2             `json:"requestors"`
+	RequestFor            OptNilRequestForV2       `json:"request_for"`
+	AccessTargets         []AccessTargetV2         `json:"access_targets"`
+	ApproverPolicy        OptNilApproverPolicyV2   `json:"approver_policy"`
+	EscalationPolicy      OptNilEscalationPolicyV2 `json:"escalation_policy"`
 	// Duration of access granted to the user, in minutes.
 	GrantDurationInMin OptNilInt32                 `json:"grant_duration_in_min"`
 	Timeframe          OptNilAccessFlowTimeframeV2 `json:"timeframe"`
@@ -435,6 +453,11 @@ func (s *AccessFlowV2) GetActive() bool {
 // GetTrigger returns the value of Trigger.
 func (s *AccessFlowV2) GetTrigger() string {
 	return s.Trigger
+}
+
+// GetRequestorIdentityType returns the value of RequestorIdentityType.
+func (s *AccessFlowV2) GetRequestorIdentityType() string {
+	return s.RequestorIdentityType
 }
 
 // GetRequestors returns the value of Requestors.
@@ -515,6 +538,11 @@ func (s *AccessFlowV2) SetActive(val bool) {
 // SetTrigger sets the value of Trigger.
 func (s *AccessFlowV2) SetTrigger(val string) {
 	s.Trigger = val
+}
+
+// SetRequestorIdentityType sets the value of RequestorIdentityType.
+func (s *AccessFlowV2) SetRequestorIdentityType(val string) {
+	s.RequestorIdentityType = val
 }
 
 // SetRequestors sets the value of Requestors.
@@ -1093,7 +1121,9 @@ type BundleV2 struct {
 	// Unique identifier of the bundle.
 	ID string `json:"id"`
 	// Display name of the bundle.
-	Name          string                       `json:"name"`
+	Name string `json:"name"`
+	// Description of the bundle.
+	Description   OptNilString                 `json:"description"`
 	AccessTargets []AccessBundleAccessTargetV2 `json:"access_targets"`
 	// Space this bundle belongs to.
 	Space OptNilSpaceReferenceV1 `json:"space"`
@@ -1111,6 +1141,11 @@ func (s *BundleV2) GetID() string {
 // GetName returns the value of Name.
 func (s *BundleV2) GetName() string {
 	return s.Name
+}
+
+// GetDescription returns the value of Description.
+func (s *BundleV2) GetDescription() OptNilString {
+	return s.Description
 }
 
 // GetAccessTargets returns the value of AccessTargets.
@@ -1141,6 +1176,11 @@ func (s *BundleV2) SetID(val string) {
 // SetName sets the value of Name.
 func (s *BundleV2) SetName(val string) {
 	s.Name = val
+}
+
+// SetDescription sets the value of Description.
+func (s *BundleV2) SetDescription(val OptNilString) {
+	s.Description = val
 }
 
 // SetAccessTargets sets the value of AccessTargets.
@@ -6133,13 +6173,20 @@ func (s *UpsertAccessScopeV1) SetQuery(val string) {
 // Ref: #/components/schemas/UpsertBundleV2
 type UpsertBundleV2 struct {
 	// Display name of the bundle.
-	Name          string                             `json:"name"`
+	Name string `json:"name"`
+	// Description of the bundle.
+	Description   OptNilString                       `json:"description"`
 	AccessTargets []AccessBundleAccessTargetUpsertV2 `json:"access_targets"`
 }
 
 // GetName returns the value of Name.
 func (s *UpsertBundleV2) GetName() string {
 	return s.Name
+}
+
+// GetDescription returns the value of Description.
+func (s *UpsertBundleV2) GetDescription() OptNilString {
+	return s.Description
 }
 
 // GetAccessTargets returns the value of AccessTargets.
@@ -6150,6 +6197,11 @@ func (s *UpsertBundleV2) GetAccessTargets() []AccessBundleAccessTargetUpsertV2 {
 // SetName sets the value of Name.
 func (s *UpsertBundleV2) SetName(val string) {
 	s.Name = val
+}
+
+// SetDescription sets the value of Description.
+func (s *UpsertBundleV2) SetDescription(val OptNilString) {
+	s.Description = val
 }
 
 // SetAccessTargets sets the value of AccessTargets.

--- a/internal/v2/api/openapi.json
+++ b/internal/v2/api/openapi.json
@@ -1169,6 +1169,15 @@
             }
           },
           {
+            "name": "requestor_identity_type",
+            "in": "query",
+            "description": "Filter access flows by the requestor identity type they serve. Allowed values: HUMAN, AGENT.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
             "name": "space_references",
             "in": "query",
             "description": "List of space IDs or names to filter results by. If omitted, returns objects from all spaces. To return only objects that belong to no space, include the special value \"null\" in the list",
@@ -4509,6 +4518,7 @@
           "name",
           "active",
           "trigger",
+          "requestor_identity_type",
           "requestors",
           "access_targets",
           "settings",
@@ -4531,6 +4541,10 @@
           },
           "trigger": {
             "description": "Event or action that triggers the access flow",
+            "type": "string"
+          },
+          "requestor_identity_type": {
+            "description": "The type of identity that can request access through this flow. HUMAN (default) = reachable only by human requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed values: HUMAN, AGENT.",
             "type": "string"
           },
           "requestors": {
@@ -4667,6 +4681,7 @@
           "name",
           "active",
           "trigger",
+          "requestor_identity_type",
           "requestors",
           "access_targets",
           "settings",
@@ -4693,6 +4708,10 @@
           },
           "trigger": {
             "description": "Event or action that triggers the access flow",
+            "type": "string"
+          },
+          "requestor_identity_type": {
+            "description": "The type of identity that can request access through this flow. HUMAN = reachable only by human requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed values: HUMAN, AGENT.",
             "type": "string"
           },
           "requestors": {
@@ -5695,6 +5714,11 @@
           "name": {
             "description": "Display name of the bundle",
             "type": "string"
+          },
+          "description": {
+            "description": "Description of the bundle",
+            "type": "string",
+            "nullable": true
           },
           "access_targets": {
             "type": "array",
@@ -8996,6 +9020,11 @@
           "name": {
             "description": "Display name of the bundle",
             "type": "string"
+          },
+          "description": {
+            "description": "Description of the bundle",
+            "type": "string",
+            "nullable": true
           },
           "access_targets": {
             "type": "array",

--- a/internal/v2/common/consts.go
+++ b/internal/v2/common/consts.go
@@ -3,4 +3,5 @@ package common
 const ResourceCategory = "RESOURCES"
 const UserInformationCategory = "USER-INFORMATION"
 const DefaultMatchOperator = "is"
+const DefaultRequestorIdentityType = "HUMAN"
 const MockDuck = "mock-duck"

--- a/internal/v2/models/access_flow.go
+++ b/internal/v2/models/access_flow.go
@@ -3,21 +3,22 @@ package models
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type AccessFlowV2Model struct {
-	ID                 types.String                  `tfsdk:"id"`
-	Name               types.String                  `tfsdk:"name"`
-	Description        types.String                  `tfsdk:"description"`
-	Active             types.Bool                    `tfsdk:"active"`
-	Trigger            types.String                  `tfsdk:"trigger"`
-	GrantDurationInMin types.Int32                   `tfsdk:"grant_duration_in_min"`
-	Timeframe          *AccessFlowTimeframeModel     `tfsdk:"timeframe"`
-	ApproverPolicy     *AccessFlowApproverPolicy     `tfsdk:"approver_policy"`
-	EscalationPolicy   *EscalationPolicyModel        `tfsdk:"escalation_policy"`
-	Requestors         *AccessFlowRequestorsModel    `tfsdk:"requestors"`
-	RequestFor         *AccessFlowRequestForModel    `tfsdk:"request_for"`
-	AccessTargets      []AccessFlowAccessTargetModel `tfsdk:"access_targets"`
-	Settings           *AccessFlowSettingsModel      `tfsdk:"settings"`
-	SpaceReference     types.String                  `tfsdk:"space_reference"`
-	Space              types.Object                  `tfsdk:"space"`
+	ID                    types.String                  `tfsdk:"id"`
+	Name                  types.String                  `tfsdk:"name"`
+	Description           types.String                  `tfsdk:"description"`
+	Active                types.Bool                    `tfsdk:"active"`
+	Trigger               types.String                  `tfsdk:"trigger"`
+	RequestorIdentityType types.String                  `tfsdk:"requestor_identity_type"`
+	GrantDurationInMin    types.Int32                   `tfsdk:"grant_duration_in_min"`
+	Timeframe             *AccessFlowTimeframeModel     `tfsdk:"timeframe"`
+	ApproverPolicy        *AccessFlowApproverPolicy     `tfsdk:"approver_policy"`
+	EscalationPolicy      *EscalationPolicyModel        `tfsdk:"escalation_policy"`
+	Requestors            *AccessFlowRequestorsModel    `tfsdk:"requestors"`
+	RequestFor            *AccessFlowRequestForModel    `tfsdk:"request_for"`
+	AccessTargets         []AccessFlowAccessTargetModel `tfsdk:"access_targets"`
+	Settings              *AccessFlowSettingsModel      `tfsdk:"settings"`
+	SpaceReference        types.String                  `tfsdk:"space_reference"`
+	Space                 types.Object                  `tfsdk:"space"`
 }
 
 type AccessFlowTimeframeModel struct {

--- a/internal/v2/models/access_flow_to_model.go
+++ b/internal/v2/models/access_flow_to_model.go
@@ -12,10 +12,11 @@ import (
 
 func AccessFlowResponseToModel(ctx context.Context, response client.AccessFlowV2) (*AccessFlowV2Model, error) {
 	model := AccessFlowV2Model{
-		ID:      types.StringValue(response.ID),
-		Name:    types.StringValue(response.Name),
-		Active:  types.BoolValue(response.Active),
-		Trigger: types.StringValue(response.Trigger),
+		ID:                    types.StringValue(response.ID),
+		Name:                  types.StringValue(response.Name),
+		Active:                types.BoolValue(response.Active),
+		Trigger:               types.StringValue(response.Trigger),
+		RequestorIdentityType: types.StringValue(response.RequestorIdentityType),
 	}
 
 	if val, ok := response.Description.Get(); ok {

--- a/internal/v2/models/access_flow_to_model.go
+++ b/internal/v2/models/access_flow_to_model.go
@@ -11,12 +11,19 @@ import (
 )
 
 func AccessFlowResponseToModel(ctx context.Context, response client.AccessFlowV2) (*AccessFlowV2Model, error) {
+	// Normalize an empty/missing requestor_identity_type to the schema default (HUMAN)
+	// so older servers that omit the field don't cause perpetual diffs against the default.
+	requestorIdentityType := response.RequestorIdentityType
+	if requestorIdentityType == "" {
+		requestorIdentityType = common.DefaultRequestorIdentityType
+	}
+
 	model := AccessFlowV2Model{
 		ID:                    types.StringValue(response.ID),
 		Name:                  types.StringValue(response.Name),
 		Active:                types.BoolValue(response.Active),
 		Trigger:               types.StringValue(response.Trigger),
-		RequestorIdentityType: types.StringValue(response.RequestorIdentityType),
+		RequestorIdentityType: types.StringValue(requestorIdentityType),
 	}
 
 	if val, ok := response.Description.Get(); ok {

--- a/internal/v2/models/access_flow_to_model_test.go
+++ b/internal/v2/models/access_flow_to_model_test.go
@@ -11,10 +11,11 @@ import (
 
 func TestAccessFlowResponseToModel(t *testing.T) {
 	response := client.AccessFlowV2{
-		ID:      "flow-123",
-		Name:    "postgresql_prod",
-		Active:  true,
-		Trigger: "SELF_SERVE",
+		ID:                    "flow-123",
+		Name:                  "postgresql_prod",
+		Active:                true,
+		Trigger:               "SELF_SERVE",
+		RequestorIdentityType: "HUMAN",
 		Settings: client.AccessFlowSettingsV2{
 			JustificationRequired:         true,
 			RequireApproverReason:         false,
@@ -144,6 +145,7 @@ func TestAccessFlowResponseToModel(t *testing.T) {
 	assert.Equal(t, "postgresql_prod", model.Name.ValueString())
 	assert.True(t, model.Active.ValueBool())
 	assert.Equal(t, "SELF_SERVE", model.Trigger.ValueString())
+	assert.Equal(t, "HUMAN", model.RequestorIdentityType.ValueString())
 	assert.Equal(t, int32(60), model.GrantDurationInMin.ValueInt32())
 
 	require.NotNil(t, model.Timeframe)

--- a/internal/v2/models/access_flow_to_model_test.go
+++ b/internal/v2/models/access_flow_to_model_test.go
@@ -308,6 +308,8 @@ func TestAccessFlowResponseToModelMinimalFields(t *testing.T) {
 	assert.Equal(t, "minimal_flow", model.Name.ValueString())
 	assert.False(t, model.Active.ValueBool())
 	assert.Equal(t, "AUTOMATIC", model.Trigger.ValueString())
+	// requestor_identity_type omitted by the server is normalized to the schema default.
+	assert.Equal(t, "HUMAN", model.RequestorIdentityType.ValueString())
 	assert.True(t, model.GrantDurationInMin.IsNull())
 	assert.Nil(t, model.Timeframe)
 	assert.Nil(t, model.ApproverPolicy)

--- a/internal/v2/models/access_flow_to_request.go
+++ b/internal/v2/models/access_flow_to_request.go
@@ -9,9 +9,10 @@ import (
 
 func AccessFlowModelToUpsertRequest(ctx context.Context, model AccessFlowV2Model) (*client.AccessFlowUpsertV2, error) {
 	upsert := client.AccessFlowUpsertV2{
-		Name:    model.Name.ValueString(),
-		Active:  model.Active.ValueBool(),
-		Trigger: model.Trigger.ValueString(),
+		Name:                  model.Name.ValueString(),
+		Active:                model.Active.ValueBool(),
+		Trigger:               model.Trigger.ValueString(),
+		RequestorIdentityType: model.RequestorIdentityType.ValueString(),
 	}
 
 	if !model.Description.IsNull() {

--- a/internal/v2/models/access_flow_to_request_test.go
+++ b/internal/v2/models/access_flow_to_request_test.go
@@ -13,10 +13,11 @@ import (
 
 func TestAccessFlowV2ModelToUpsertRequest(t *testing.T) {
 	model := AccessFlowV2Model{
-		Name:               types.StringValue("postgresql_prod"),
-		Active:             types.BoolValue(true),
-		Trigger:            types.StringValue("SELF_SERVE"),
-		GrantDurationInMin: types.Int32Null(),
+		Name:                  types.StringValue("postgresql_prod"),
+		Active:                types.BoolValue(true),
+		Trigger:               types.StringValue("SELF_SERVE"),
+		RequestorIdentityType: types.StringValue("AGENT"),
+		GrantDurationInMin:    types.Int32Null(),
 		Timeframe: &AccessFlowTimeframeModel{
 			StartTime:  types.StringValue("10:00"),
 			EndTime:    types.StringValue("23:59"),
@@ -124,6 +125,7 @@ func TestAccessFlowV2ModelToUpsertRequest(t *testing.T) {
 	assert.Equal(t, "postgresql_prod", result.Name)
 	assert.True(t, result.Active)
 	assert.Equal(t, "SELF_SERVE", result.Trigger)
+	assert.Equal(t, "AGENT", result.RequestorIdentityType)
 	assert.False(t, result.GrantDurationInMin.IsSet())
 
 	require.True(t, result.Timeframe.IsSet())

--- a/internal/v2/resources/apono_access_flow_v2_resource.go
+++ b/internal/v2/resources/apono_access_flow_v2_resource.go
@@ -136,7 +136,7 @@ func (r *AponoAccessFlowV2Resource) Schema(_ context.Context, _ resource.SchemaR
 				Description: "The type of identity that can request access through this flow. HUMAN (default) = reachable only by human requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed values: HUMAN, AGENT.",
 				Optional:    true,
 				Computed:    true,
-				Default:     stringdefault.StaticString("HUMAN"),
+				Default:     stringdefault.StaticString(common.DefaultRequestorIdentityType),
 				Validators: []validator.String{
 					stringvalidator.OneOf("HUMAN", "AGENT"),
 				},

--- a/internal/v2/resources/apono_access_flow_v2_resource.go
+++ b/internal/v2/resources/apono_access_flow_v2_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apono-io/terraform-provider-apono/internal/v2/models"
 	"github.com/apono-io/terraform-provider-apono/internal/v2/schemas"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -130,6 +131,15 @@ func (r *AponoAccessFlowV2Resource) Schema(_ context.Context, _ resource.SchemaR
 			"trigger": schema.StringAttribute{
 				Description: `The trigger type for the access flow. Possible values: SELF_SERVE, AUTOMATIC.`,
 				Required:    true,
+			},
+			"requestor_identity_type": schema.StringAttribute{
+				Description: "The type of identity that can request access through this flow. HUMAN (default) = reachable only by human requestors; AGENT = reachable only by AI agents acting on behalf of a user. Allowed values: HUMAN, AGENT.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("HUMAN"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("HUMAN", "AGENT"),
+				},
 			},
 			"grant_duration_in_min": schema.Int32Attribute{
 				Description: "How long access is granted, in minutes. If not specified, the grant duration defaults to indefinite.",

--- a/internal/v2/resources/apono_access_flow_v2_resource_test.go
+++ b/internal/v2/resources/apono_access_flow_v2_resource_test.go
@@ -188,6 +188,7 @@ resource "apono_access_flow_v2" "test_with_request_for" {
 					resource.TestCheckResourceAttr(resourceName, "description", "test access flow description"),
 					resource.TestCheckResourceAttr(resourceName, "trigger", "SELF_SERVE"),
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "requestor_identity_type", "HUMAN"),
 					resource.TestCheckResourceAttr(resourceName, "requestors.logical_operator", "OR"),
 					resource.TestCheckResourceAttr(resourceName, "access_targets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "settings.justification_required", "true"),
@@ -297,4 +298,90 @@ resource "apono_access_flow_v2" "test" {
   settings = {}
 }
 `, name, userEmail)
+}
+
+func TestAccAponoAccessFlowV2ResourceRequestorIdentityType(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "apono_access_flow_v2.test"
+
+	users, err := testcommon.GetUsers(t)
+	if err != nil {
+		t.Fatalf("failed to get users: %v", err)
+	}
+	if len(users) < 1 {
+		t.Fatalf("need at least 1 user for test, found %d", len(users))
+	}
+	userEmail := users[0].Email
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testcommon.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testprovider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// requestor_identity_type omitted -> defaults to HUMAN.
+				Config: testAccAponoAccessFlowV2RequestorIdentityTypeConfig(rName, userEmail, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "requestor_identity_type", "HUMAN"),
+				),
+			},
+			{
+				// Explicit AGENT flow.
+				Config: testAccAponoAccessFlowV2RequestorIdentityTypeConfig(rName, userEmail, "AGENT"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "requestor_identity_type", "AGENT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Explicit HUMAN flow.
+				Config: testAccAponoAccessFlowV2RequestorIdentityTypeConfig(rName, userEmail, "HUMAN"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "requestor_identity_type", "HUMAN"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAponoAccessFlowV2RequestorIdentityTypeConfig(name, userEmail, requestorIdentityType string) string {
+	requestorIdentityTypeLine := ""
+	if requestorIdentityType != "" {
+		requestorIdentityTypeLine = fmt.Sprintf("requestor_identity_type = %q", requestorIdentityType)
+	}
+
+	return fmt.Sprintf(`
+resource "apono_access_flow_v2" "test" {
+  name    = "%[1]s"
+  trigger = "SELF_SERVE"
+  active  = true
+  %[3]s
+
+  requestors = {
+    logical_operator = "OR"
+    conditions = [
+      {
+        type   = "user"
+        values = ["%[2]s"]
+      }
+    ]
+  }
+
+  access_targets = [
+    {
+      query_target = {
+        query = "resource_type = \"mock-duck\""
+      }
+    }
+  ]
+
+  settings = {}
+}
+`, name, userEmail, requestorIdentityTypeLine)
 }

--- a/internal/v2/testcommon/access_flow.go
+++ b/internal/v2/testcommon/access_flow.go
@@ -6,10 +6,11 @@ import (
 
 func GenerateAccessFlowResponse() *client.AccessFlowV2 {
 	response := client.AccessFlowV2{
-		ID:      "flow-123",
-		Name:    "postgresql_prod",
-		Active:  true,
-		Trigger: "SELF_SERVE",
+		ID:                    "flow-123",
+		Name:                  "postgresql_prod",
+		Active:                true,
+		Trigger:               "SELF_SERVE",
+		RequestorIdentityType: "HUMAN",
 		Settings: client.AccessFlowSettingsV2{
 			JustificationRequired:         true,
 			RequireApproverReason:         false,

--- a/templates/resources/access_flow_v2.md.tmpl
+++ b/templates/resources/access_flow_v2.md.tmpl
@@ -19,6 +19,12 @@ description: |-
 
 {{ tffile "examples/resources/apono_access_flow_v2/automatic-approval.tf" }}
 
+### Agent Access Flow — Requestor Identity Type
+
+Restrict a flow to AI agents acting on behalf of a user by setting `requestor_identity_type = "AGENT"`. Omit the attribute (or set it to `"HUMAN"`) for the default human-requestor behavior. Agent flows are request-driven and do not support the `AUTOMATIC` trigger.
+
+{{ tffile "examples/resources/apono_access_flow_v2/agent-identity.tf" }}
+
 ### Auto-approved Access Flow for on-call OpsGenie responders
 
 Auto-approved Access Flow for on-call OpsGenie responders to request access on behalf of the R&D group.

--- a/templates/resources/access_flow_v2.md.tmpl
+++ b/templates/resources/access_flow_v2.md.tmpl
@@ -21,7 +21,7 @@ description: |-
 
 ### Agent Access Flow — Requestor Identity Type
 
-Restrict a flow to AI agents acting on behalf of a user by setting `requestor_identity_type = "AGENT"`. Omit the attribute (or set it to `"HUMAN"`) for the default human-requestor behavior. Agent flows are request-driven and do not support the `AUTOMATIC` trigger.
+Restrict a flow to AI agents acting on behalf of a user by setting `requestor_identity_type = "AGENT"`. Omit the attribute (or set it to `"HUMAN"`) for the default human-requestor behavior. Agent flows are request-driven; Apono rejects the combination of `requestor_identity_type = "AGENT"` with `trigger = "AUTOMATIC"` and returns an error.
 
 {{ tffile "examples/resources/apono_access_flow_v2/agent-identity.tf" }}
 


### PR DESCRIPTION
Add a new top-level `requestor_identity_type` attribute to the `apono_access_flow_v2` resource. It segregates a flow to either human requestors (HUMAN, default) or AI agents acting on behalf of a user (AGENT).

- Schema: Optional + Computed, default "HUMAN", OneOf("HUMAN","AGENT") validator so existing configs keep working unchanged.
- Wire the field through model <-> request/response conversions.
- Unit tests assert round-trip for HUMAN and AGENT.
- Acceptance test covers omitted->HUMAN, explicit AGENT, import, and switching back to HUMAN.
- Add agent-identity example and regenerate docs.

The list endpoint gains a `requestor_identity_type` query param in the generated client; no data source exists to wire it to, so no data source changes per product guidance.